### PR TITLE
feat(1259): sort projects based on dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/google/go-github/v41 v41.0.0 // indirect
+	github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -495,6 +495,8 @@ github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKn
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/xanzy/go-gitlab v0.54.3 h1:fPfZ3Jcu5dPc3xyIYtAALZsEgoyKNFNuULD+TdJ7Zvk=
 github.com/xanzy/go-gitlab v0.54.3/go.mod h1:F0QEXwmqiBUxCgJm8fE9S+1veX4XC9Z4cfaAbqwk4YM=
+github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869 h1:7v7L5lsfw4w8iqBBXETukHo4IPltmD+mWoLRYUmeGN8=
+github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869/go.mod h1:Rfzr+sqaDreiCaoQbFCu3sTXxeFq/9kXRuyOoSlGQHE=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/server/events/project_finder.go
+++ b/server/events/project_finder.go
@@ -14,12 +14,14 @@
 package events
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/runatlantis/atlantis/server/events/yaml/valid"
+	"github.com/yourbasic/graph"
 
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/pkg/errors"
@@ -83,6 +85,7 @@ func (p *DefaultProjectFinder) DetermineProjects(log logging.SimpleLogging, modi
 // See ProjectFinder.DetermineProjectsViaConfig.
 func (p *DefaultProjectFinder) DetermineProjectsViaConfig(log logging.SimpleLogging, modifiedFiles []string, config valid.RepoCfg, absRepoDir string) ([]valid.Project, error) {
 	var projects []valid.Project
+	var projectsToDependentFiles [][]string
 	for _, project := range config.Projects {
 		log.Debug("checking if project at dir %q workspace %q was modified", project.Dir, project.Workspace)
 		var whenModifiedRelToRepoRoot []string
@@ -110,6 +113,8 @@ func (p *DefaultProjectFinder) DetermineProjectsViaConfig(log logging.SimpleLogg
 			return nil, errors.Wrapf(err, "matching modified files with patterns: %v", project.Autoplan.WhenModified)
 		}
 
+		var matchedFiles []string
+
 		// If any of the modified files matches the pattern then this project is
 		// considered modified.
 		for _, file := range modifiedFiles {
@@ -118,30 +123,157 @@ func (p *DefaultProjectFinder) DetermineProjectsViaConfig(log logging.SimpleLogg
 				log.Debug("match err for file %q: %s", file, err)
 				continue
 			}
-			if match {
-				log.Debug("file %q matched pattern", file)
-				// If we're checking using an atlantis.yaml file we downloaded
-				// directly from the repo (when doing a no-clone check) then
-				// absRepoDir will be empty. Since we didn't clone the repo
-				// yet we can't do this check. If there was a file modified
-				// in a deleted directory then when we finally do clone the repo
-				// we'll call this function again and then we'll detect the
-				// directory was deleted.
-				if absRepoDir != "" {
-					_, err := os.Stat(filepath.Join(absRepoDir, project.Dir))
-					if err == nil {
-						projects = append(projects, project)
-					} else {
-						log.Debug("project at dir %q not included because dir does not exist", project.Dir)
-					}
-				} else {
-					projects = append(projects, project)
-				}
-				break
+
+			if !match {
+				continue
+			}
+
+			log.Debug("file %q matched pattern", file)
+
+			// If we're checking using an atlantis.yaml file we downloaded
+			// directly from the repo (when doing a no-clone check) then
+			// absRepoDir will be empty. Since we didn't clone the repo
+			// yet we can't do this check. If there was a file modified
+			// in a deleted directory then when we finally do clone the repo
+			// we'll call this function again and then we'll detect the
+			// directory was deleted.
+			if projectDirDeleted(absRepoDir, project.Dir) {
+				log.Debug("project at dir %q not included because dir does not exist", project.Dir)
+				continue
+			}
+
+			matchedFiles = append(matchedFiles, file)
+		}
+
+		if 0 < len(matchedFiles) {
+			projects = append(projects, project)
+			projectsToDependentFiles = append(projectsToDependentFiles, matchedFiles)
+		}
+	}
+
+	if 1 < len(projects) {
+		sorted, err := sortProjectsByDependencies(log, projects, projectsToDependentFiles, absRepoDir)
+
+		if err != nil {
+			// return nil, errors.Wrapf(err, "Unable to sort plans: %s", err)
+			// Used unsorted projects instead
+		} else {
+			projects = sorted
+		}
+	}
+
+	return projects, nil
+}
+
+func projectDirDeleted(absRepoDir, projectDir string) bool {
+	if absRepoDir == "" {
+		return false
+	}
+
+	if _, err := os.Stat(filepath.Join(absRepoDir, projectDir)); err != nil {
+		return true
+	}
+
+	return false
+}
+
+func projectToBeDestroyed(project valid.Project, absRepoDir string) (bool, error) {
+	terragruntFile := filepath.Join(absRepoDir, project.Dir, "terragrunt.hcl")
+
+	if _, err := os.Stat(terragruntFile); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, errors.Wrapf(err, "determining existance of %q", terragruntFile)
+	}
+
+	data, err := os.ReadFile(terragruntFile)
+	if err != nil {
+		return false, errors.Wrapf(err, "reading file %q", terragruntFile)
+	}
+
+	if strings.HasPrefix(strings.TrimSpace(string(data)), "# ATLANTIS_PLEASE_DESTROY_STACK") {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func printGraph(g *graph.Mutable, projects []valid.Project) string {
+	output := "digraph G {\n"
+
+	for i := 0; i < g.Order(); i++ {
+		output += fmt.Sprintf("    %d [label=\"%s\"];\n", i, projects[i].Dir)
+	}
+	for i := 0; i < g.Order(); i++ {
+		g.Visit(i, func(w int, to int64) bool { output += fmt.Sprintf("    %d -> %d;\n", i, w); return false })
+	}
+	output += "}\n"
+
+	return output
+}
+
+func sortProjectsByDependencies(log logging.SimpleLogging, projects []valid.Project, projectsToDependentFiles [][]string, absRepoDir string) ([]valid.Project, error) {
+	g := graph.New(len(projects))
+
+	for currentProjectIndex, files := range projectsToDependentFiles {
+		if 0 == len(files) {
+			continue
+		}
+
+		toBeDestroyed, err := projectToBeDestroyed(projects[currentProjectIndex], absRepoDir)
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "determining whether or not to apply destroy order for topological sort")
+		}
+
+		for _, file := range files {
+			if !strings.Contains(file, string(os.PathSeparator)+"terragrunt.hcl") {
+				continue
+			}
+			from, err := FindProjectNo(projects, file)
+
+			if err != nil {
+				return nil, errors.Wrapf(err, "creating dependency graph for topological sort")
+			}
+
+			if currentProjectIndex == from {
+				continue // don't add an edge to itself e.g. (u,u)
+			}
+			if toBeDestroyed {
+				g.Add(currentProjectIndex, from)
+			} else {
+				g.Add(from, currentProjectIndex)
 			}
 		}
 	}
-	return projects, nil
+
+	// TODO before contributing to github, make this a Debug() or delete
+	log.Info("Dependency Graph:\n%s\n", printGraph(g, projects))
+	sortedIndices, isSorted := graph.TopSort(g)
+
+	if !isSorted {
+		return nil, fmt.Errorf("topological sort failed on %#v", projectsToDependentFiles)
+	}
+
+	var sortedProjects []valid.Project
+
+	for _, index := range sortedIndices {
+		sortedProjects = append(sortedProjects, projects[index])
+	}
+
+	return sortedProjects, nil
+}
+
+func FindProjectNo(projects []valid.Project, file string) (int, error) {
+	for i, project := range projects {
+		if strings.Contains(file, project.Dir+string(os.PathSeparator)) {
+			return i, nil
+		}
+	}
+
+	return -1, fmt.Errorf("Did not find %q in %#v", file, projects)
 }
 
 // filterToFileList filters out files not included in the file list

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -719,38 +719,6 @@ projects:
 			destroyFlagSet: true,
 			expError:       "",
 		},
-		{
-			description: "test dependency loop",
-			AtlantisYAML: `
-version: 3
-projects:
-- autoplan:
-    enabled: true
-    when_modified:
-    - '*.hcl'
-    - '*.tf*'
-    - ../1/terragrunt.hcl
-  dir: dependency-test/2
-- autoplan:
-    enabled: true
-    when_modified:
-    - '*.hcl'
-    - '*.tf*'
-    - ../2/terragrunt.hcl
-  dir: dependency-test/3
-- autoplan:
-    enabled: true
-    when_modified:
-    - '*.hcl'
-    - '*.tf*'
-    - ../3/terragrunt.hcl
-  dir: dependency-test/1
-`,
-			modified:       []string{"dependency-test/1/terragrunt.hcl", "dependency-test/2/terragrunt.hcl", "dependency-test/3/terragrunt.hcl"},
-			expProjPaths:   []string{},
-			destroyFlagSet: false,
-			expError:       "topological sort failed",
-		},
 	}
 
 	for _, c := range cases {

--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -16,9 +16,11 @@ package events_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/runatlantis/atlantis/server/events"
+	"github.com/runatlantis/atlantis/server/events/yaml"
 	"github.com/runatlantis/atlantis/server/events/yaml/valid"
 	"github.com/runatlantis/atlantis/server/logging"
 	. "github.com/runatlantis/atlantis/testing"
@@ -510,6 +512,263 @@ func TestDefaultProjectFinder_DetermineProjectsViaConfig(t *testing.T) {
 			Equals(t, len(c.expProjPaths), len(projects))
 			for i, proj := range projects {
 				Equals(t, c.expProjPaths[i], proj.Dir)
+			}
+		})
+	}
+}
+
+func createTerragruntFiles(t *testing.T, files []string, destroyFlagSet bool) (string, func()) {
+	content := ""
+
+	if destroyFlagSet {
+		content = "# ATLANTIS_PLEASE_DESTROY_STACK\n"
+	}
+
+	dirs := make(map[string]interface{})
+
+	for _, file := range files {
+		var currentDirPtr map[string]interface{} = dirs
+
+		folders := strings.Split(file, string(os.PathSeparator))
+
+		for i, folder := range folders {
+			if i == len(folders)-1 { // last item in folders is the filename
+				currentDirPtr[folder] = content
+				continue
+			}
+
+			if _, ok := currentDirPtr[folder]; !ok {
+				currentDirPtr[folder] = make(map[string]interface{})
+			}
+
+			currentDirPtr = currentDirPtr[folder].(map[string]interface{})
+		}
+	}
+
+	return DirStructure(t, dirs)
+}
+
+func createDirEnv(t *testing.T, files []string, atlantisYaml string, destroyFlagSet bool) (valid.RepoCfg, string, func()) {
+	tmpDir, cleanup := createTerragruntFiles(t, files, destroyFlagSet)
+
+	if atlantisYaml != "" {
+		err := os.WriteFile(filepath.Join(tmpDir, yaml.AtlantisYAMLFilename), []byte(atlantisYaml), 0600)
+		Ok(t, err)
+	}
+	r := yaml.ParserValidator{}
+	var globalCfg = valid.NewGlobalCfg(true, false, false)
+	config, err := r.ParseRepoCfg(tmpDir, globalCfg, "")
+	Ok(t, err)
+
+	return config, tmpDir, cleanup
+}
+
+func TestDefaultProjectFinder_DetermineProjectsViaConfig_FindProjectNo(t *testing.T) {
+	noopLogger := logging.NewNoopLogger(t)
+	cases := []struct {
+		description  string
+		AtlantisYAML string
+		modified     []string
+	}{
+		{
+			description: "test FindProjectNo",
+			AtlantisYAML: `
+version: 3
+projects:
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: dkprto/icawtopr/foo
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../foo/terragrunt.hcl
+  dir: dkprto/icawtopr/foo-attachment
+`,
+			modified: []string{"dkprto/icawtopr/foo/terragrunt.hcl", "dkprto/icawtopr/foo-attachment/terragrunt.hcl"},
+		},
+		{
+			description: "test FindProjectNo with reverse atlantis config",
+			AtlantisYAML: `
+version: 3
+projects:
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../foo/terragrunt.hcl
+  dir: dkprto/icawtopr/foo-attachment
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: dkprto/icawtopr/foo
+`,
+			modified: []string{"dkprto/icawtopr/foo/terragrunt.hcl", "dkprto/icawtopr/foo-attachment/terragrunt.hcl"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			config, tmpDir, cleanup := createDirEnv(t, c.modified, c.AtlantisYAML, false)
+			defer cleanup()
+
+			pf := events.DefaultProjectFinder{}
+
+			projects, err := pf.DetermineProjectsViaConfig(noopLogger, c.modified, config, tmpDir)
+			Ok(t, err)
+
+			for _, file := range c.modified {
+				index, err := events.FindProjectNo(projects, file)
+				Ok(t, err)
+				Equals(t, projects[index].Dir, filepath.Dir(file))
+			}
+		})
+	}
+}
+
+func TestDefaultProjectFinder_DetermineProjectsViaConfig_TestDependencyTracking(t *testing.T) {
+	noopLogger := logging.NewNoopLogger(t)
+	cases := []struct {
+		description    string
+		AtlantisYAML   string
+		modified       []string
+		expProjPaths   []string
+		destroyFlagSet bool
+		expError       string
+	}{
+		{
+			description: "test dependency ordering",
+			AtlantisYAML: `
+version: 3
+projects:
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../4/terragrunt.hcl
+  dir: dependency-test/1
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../3/terragrunt.hcl
+  dir: dependency-test/2
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../1/terragrunt.hcl
+  dir: dependency-test/3
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: dependency-test/4
+`,
+			modified:       []string{"dependency-test/1/terragrunt.hcl", "dependency-test/2/terragrunt.hcl", "dependency-test/3/terragrunt.hcl", "dependency-test/4/terragrunt.hcl"},
+			expProjPaths:   []string{"dependency-test/4", "dependency-test/1", "dependency-test/3", "dependency-test/2"},
+			destroyFlagSet: false,
+			expError:       "",
+		},
+		{
+			description: "test reverted dependency ordering for destroy workflows",
+			AtlantisYAML: `
+version: 3
+projects:
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../4/terragrunt.hcl
+  dir: dependency-test/1
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../3/terragrunt.hcl
+  dir: dependency-test/2
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../1/terragrunt.hcl
+  dir: dependency-test/3
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+  dir: dependency-test/4
+`,
+			modified:       []string{"dependency-test/1/terragrunt.hcl", "dependency-test/2/terragrunt.hcl", "dependency-test/3/terragrunt.hcl", "dependency-test/4/terragrunt.hcl"},
+			expProjPaths:   []string{"dependency-test/2", "dependency-test/3", "dependency-test/1", "dependency-test/4"},
+			destroyFlagSet: true,
+			expError:       "",
+		},
+		{
+			description: "test dependency loop",
+			AtlantisYAML: `
+version: 3
+projects:
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../1/terragrunt.hcl
+  dir: dependency-test/2
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../2/terragrunt.hcl
+  dir: dependency-test/3
+- autoplan:
+    enabled: true
+    when_modified:
+    - '*.hcl'
+    - '*.tf*'
+    - ../3/terragrunt.hcl
+  dir: dependency-test/1
+`,
+			modified:       []string{"dependency-test/1/terragrunt.hcl", "dependency-test/2/terragrunt.hcl", "dependency-test/3/terragrunt.hcl"},
+			expProjPaths:   []string{},
+			destroyFlagSet: false,
+			expError:       "topological sort failed",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			config, tmpDir, cleanup := createDirEnv(t, c.modified, c.AtlantisYAML, c.destroyFlagSet)
+			defer cleanup()
+
+			pf := events.DefaultProjectFinder{}
+
+			projects, err := pf.DetermineProjectsViaConfig(noopLogger, c.modified, config, tmpDir)
+			if c.expError == "" {
+				Ok(t, err)
+				Equals(t, len(c.expProjPaths), len(projects))
+				for i, proj := range projects {
+					Equals(t, c.expProjPaths[i], proj.Dir)
+				}
+			} else {
+				ErrContains(t, c.expError, err)
 			}
 		})
 	}


### PR DESCRIPTION
This implements:
https://github.com/runatlantis/atlantis/issues/1259

feat(1259): atlantis destroy order

While creating the directed acyclic graph, it checks if the
terragrunt.hcl file of the stacks contains our destroy flag:
`# ATLANTIS_PLEASE_DESTROY_STACK`

If this flag is found, the corresponding edge will be reverted, i.e.
instead of u -> v, we will get v -> u.

feat(1259): topological sort: fix and debugging

* this will output the dependency graph in *.dot format
* it will make the plan fail if the TopSort() fails for whatever reason
* sorting is not necessary when there is just one project
* dynamic folder/file generation
* remove some unnecessary else branches
* add a test for FindProjectNo()
* and most important: fix FindProjectNo() so that the sorting is correct